### PR TITLE
Set Java version to 17 for deploy

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=17


### PR DESCRIPTION
Add the system.properties. Now the application does explicitly specify an OpenJDK.